### PR TITLE
Fix for VS stdint.h

### DIFF
--- a/agg_regrid/__init__.py
+++ b/agg_regrid/__init__.py
@@ -32,7 +32,7 @@ from iris.analysis._interpolation import snapshot_grid, get_xy_dim_coords
 from ._agg import raster as agg_raster
 
 
-__version__ = '0.3.dev0'
+__version__ = '0.2.1'
 
 
 class AreaWeighted(object):

--- a/agg_regrid/_agg_raster.h
+++ b/agg_regrid/_agg_raster.h
@@ -20,7 +20,19 @@
 #ifndef _AGG_RASTER_H
 #define _AGG_RASTER_H
 
-#include <stdint.h>
+#ifdef _MSC_VER
+    #ifndef _MSC_STDINT_H_
+        #if _MSC_VER < 1300
+           typedef unsigned char     uint8_t;
+           typedef unsigned int      uint32_t;
+        #else
+           typedef unsigned __int8   uint8_t;
+           typedef unsigned __int32  uint32_t;
+        #endif
+    #endif
+#else
+   #include <stdint.h>
+#endif
 
 
 void _raster(uint8_t *weights, const double *xi, const double *yi,


### PR DESCRIPTION
On conda-forge the Windows python27 build is failing as it uses `vs2008_runtime`, and references to `stdint.h` were omitted until the `vs2010_runtime`.

The python35 and python36 conda-forge builds are passing, as they use the `vs2015_runtime`.

The PR attempts to circumvent this problem.