### PR TITLE
Source grid cell pixel buffer

### DIFF
--- a/agg_regrid/__init__.py
+++ b/agg_regrid/__init__.py
@@ -35,14 +35,33 @@ from ._agg import raster as agg_raster
 __version__ = '0.3.dev0'
 
 
-class AreaWeighted(object):
-    """
-    The Anti-Grain Geometry (AGG) regridding scheme for performing
-    area-weighted conservative regridding.
+# Default to using an 8x8 pixel buffer for each source grid cell.
+DEFAULT_BUFFER_DEPTH = 8
 
-    """
+
+class AreaWeighted(object):
+    def __init__(self, buffer_depth=None):
+        """
+        Anti-Grain Geometry (AGG) regridding scheme for performing
+        area-weighted conservative regridding.
+
+        Kwargs:
+
+        * buffer_depth (int):
+            The depth (N) specifying the NxN pixel buffer to be used by AGG
+            to represent each source grid cell. Increase the buffer depth for
+            regrid operations involving a high resolution target grid compared
+            to a low resolution source grid.
+
+        """
+        if buffer_depth is None:
+            buffer_depth = DEFAULT_BUFFER_DEPTH
+
+        self.buffer_depth = buffer_depth
+
     def __repr__(self):
-        return '{}()'.format(self.__class__.__name__)
+        msg = '{}(buffer_depth={})'
+        return msg.format(self.__class__.__name__, self.buffer_depth)
 
     def regridder(self, src_grid, tgt_grid):
         """
@@ -66,7 +85,8 @@ class AreaWeighted(object):
             as the source grid defined for regridding to the target grid.
 
         """
-        return _AreaWeightedRegridder(src_grid, tgt_grid)
+        return _AreaWeightedRegridder(src_grid, tgt_grid,
+                                      buffer_depth=self.buffer_depth)
 
 
 class _AreaWeightedRegridder(object):
@@ -74,7 +94,7 @@ class _AreaWeightedRegridder(object):
     This class provides support for performing area-weighted regridding.
 
     """
-    def __init__(self, src_grid_cube, tgt_grid_cube):
+    def __init__(self, src_grid_cube, tgt_grid_cube, buffer_depth=None):
         """
         Creates a area-weighted regridder which uses an Anti-Grain
         Geometry (AGG) backend to rasterise the conversion between the source
@@ -87,6 +107,14 @@ class _AreaWeightedRegridder(object):
         * tgt_grid_cube:
             The :class:`~iris.cube.Cube` providing the target grid.
 
+        Kwargs:
+
+        * buffer_depth (int):
+            The depth (N) specifying the NxN pixel buffer to be used by AGG
+            to represent each source grid cell. Increase the buffer depth for
+            regrid operations involving a high resolution target grid compared
+            to a low resolution source grid.
+
         """
         if not isinstance(src_grid_cube, iris.cube.Cube):
             emsg = 'The source grid must be a cube, got {}.'
@@ -95,6 +123,11 @@ class _AreaWeightedRegridder(object):
         if not isinstance(tgt_grid_cube, iris.cube.Cube):
             emsg = 'The target grid must be a cube, got {}.'
             raise TypeError(emsg.format(type(tgt_grid_cube)))
+
+        if buffer_depth is None:
+            buffer_depth = DEFAULT_BUFFER_DEPTH
+
+        self.buffer_depth = buffer_depth
 
         # Snapshot the state of the grid cubes to ensure that the regridder
         # is impervious to external changes to the original cubes.
@@ -179,7 +212,7 @@ class _AreaWeightedRegridder(object):
         # Perform the regrid.
         result = agg(src_cube.data, sx.points, self._sx_bounds,
                      sy.points, self._sy_bounds, sx_dim, sy_dim,
-                     self._gx_bounds, self._gy_bounds)
+                     self._gx_bounds, self._gy_bounds, self.buffer_depth)
 
         #
         # XXX: Need to deal the factories when constructing result cube.
@@ -206,7 +239,7 @@ class _AreaWeightedRegridder(object):
 
 
 def agg(data, sx_points, sx_bounds, sy_points, sy_bounds,
-        sx_dim, sy_dim, gx_bounds, gy_bounds):
+        sx_dim, sy_dim, gx_bounds, gy_bounds, depth):
     """
     Perform a area-weighted regrid of the data using an Anti-Grain
     Geometry (AGG) backend to rasterise the conversion between the source
@@ -232,13 +265,16 @@ def agg(data, sx_points, sx_bounds, sy_points, sy_bounds,
     * sx_dim:
         The data dimension of the x-coordinate.
     * sy_dim:
-        The data dimensoin of the y-coordinate.
+        The data dimension of the y-coordinate.
     * gx_bounds:
         The target grid x-coordinate contiguous bounds, which must be 2d.
         The dimensionality of the target grid is assumed to be in (y, x) order.
     * gy_bounds:
         The target grid y-coordinate contiguous bounds, which must be 2d.
         The dimensionality of the target grid is assumed to be in (y, x) order.
+    * depth:
+        The depth (N) specifying the NxN pixel buffer to represent each source
+        grid cell.
 
     Returns:
         The data with same horizontal dimensionality as the target grid. The
@@ -343,7 +379,7 @@ def agg(data, sx_points, sx_bounds, sy_points, sy_bounds,
         rtol = 0.002
         try:
             atol = mean_delta * rtol
-            np.testing.assert_allclose(delta, mean_delta, atol=atol)
+            np.testing.assert_allclose(delta, mean_delta, atol=abs(atol))
         except AssertionError as e:
             emsg = 'Expected src {}-coordinate points to be regular{}'
             raise ValueError(emsg.format(kind, e))
@@ -380,6 +416,14 @@ def agg(data, sx_points, sx_bounds, sy_points, sy_bounds,
     result_shape = tuple(result_shape)
     result.mask = True
 
+    def _sum_chunk(x, chunk_size, axis=-1):
+        shape = x.shape
+        if axis < 0:
+            axis += x.ndim
+        shape = shape[:axis] + (-1, chunk_size) + shape[axis + 1:]
+        x = x.reshape(shape)
+        return x.sum(axis=axis + 1)
+
     #
     # XXX: Cythonise this ...
     #
@@ -408,10 +452,12 @@ def agg(data, sx_points, sx_bounds, sy_points, sy_bounds,
             # overlapped by this grid cell.
             cell_xi -= xi_min
             cell_yi -= yi_min
-            weights = np.zeros((yi_max - yi_min, xi_max - xi_min),
-                               dtype=np.uint8)
-            agg_raster(weights, cell_xi, cell_yi)
-            weights = weights / 255
+            wshape = (depth*(yi_max-yi_min), depth*(xi_max-xi_min))
+            weights = np.zeros(wshape, dtype=np.uint8)
+            agg_raster(weights, depth*cell_xi, depth*cell_yi)
+            if depth > 1:
+                weights = _sum_chunk(_sum_chunk(weights, depth), depth, 0)
+            weights = weights / (depth*depth*255)
             # Now calculate the weighted result for this grid cell.
             tmp = data[:, yi_min:yi_max, xi_min:xi_max]
             result[:, yi, xi] = (tmp * weights).sum(axis=dims) / weights.sum()

--- a/agg_regrid/__init__.py
+++ b/agg_regrid/__init__.py
@@ -94,6 +94,7 @@ class _AreaWeightedRegridder(object):
     This class provides support for performing area-weighted regridding.
 
     """
+
     def __init__(self, src_grid_cube, tgt_grid_cube, buffer_depth=None):
         """
         Creates a area-weighted regridder which uses an Anti-Grain

--- a/agg_regrid/tests/test_AreaWeighted.py
+++ b/agg_regrid/tests/test_AreaWeighted.py
@@ -26,7 +26,7 @@ try:
 except ImportError:
     import mock
 
-from agg_regrid import AreaWeighted
+from agg_regrid import AreaWeighted, DEFAULT_BUFFER_DEPTH
 
 
 class Test(unittest.TestCase):
@@ -34,6 +34,7 @@ class Test(unittest.TestCase):
         self.src = mock.sentinel.src
         self.tgt = mock.sentinel.tgt
         self.regridder = mock.sentinel.regridder
+        self.depth = DEFAULT_BUFFER_DEPTH
 
     def test_regridder(self):
         regridder = 'agg_regrid._AreaWeightedRegridder'
@@ -42,7 +43,7 @@ class Test(unittest.TestCase):
             scheme = AreaWeighted()
             result = scheme.regridder(self.src, self.tgt)
             self.assertEqual(result, self.regridder)
-            expected = [mock.call(self.src, self.tgt)]
+            expected = [mock.call(self.src, self.tgt, buffer_depth=self.depth)]
             self.assertEqual(mocker.mock_calls, expected)
 
 

--- a/agg_regrid/tests/test__AreadWeightedRegridder.py
+++ b/agg_regrid/tests/test__AreadWeightedRegridder.py
@@ -28,7 +28,8 @@ try:
 except ImportError:
     import mock
 
-from agg_regrid import _AreaWeightedRegridder as Regridder
+from agg_regrid import (_AreaWeightedRegridder as Regridder,
+                        DEFAULT_BUFFER_DEPTH)
 
 
 class Test(unittest.TestCase):
@@ -143,6 +144,7 @@ class Test___call__(unittest.TestCase):
         self.side_effect = (self.src_grid, tgt_grid)
         self.snapshot_grid = 'agg_regrid.snapshot_grid'
         self.get_xy_dim_coords = 'agg_regrid.get_xy_dim_coords'
+        self.depth = DEFAULT_BUFFER_DEPTH
 
     def test_bad_src_cube(self):
         with mock.patch(self.snapshot_grid, side_effect=self.side_effect):
@@ -187,7 +189,8 @@ class Test___call__(unittest.TestCase):
         self.assertEqual(regridder._gx_bounds, gxx)
         self.assertEqual(regridder._gy_bounds, gyy)
         expected = [mock.call(self.data, self.sxp, self.sxb, self.syp,
-                              self.syb, self.sx_dim, self.sy_dim, gxx, gyy)]
+                              self.syb, self.sx_dim, self.sy_dim, gxx, gyy,
+                              self.depth)]
         self.assertEqual(magg.call_args_list, expected)
         cube = iris.cube.Cube(data)
         cube.metadata = self.metadata

--- a/agg_regrid/tests/test_agg.py
+++ b/agg_regrid/tests/test_agg.py
@@ -251,8 +251,7 @@ class TestRegridDepth(unittest.TestCase):
 
     def test(self):
         for depth in [2**i for i in range(10)]:
-            result = agg(*self.args, depth)
-            expected = self._expected(depth)
+            result = agg(*self.args, depth=depth)
             assert_array_equal(result, self._expected(depth))
 
 

--- a/agg_regrid/tests/test_agg.py
+++ b/agg_regrid/tests/test_agg.py
@@ -25,7 +25,7 @@ import numpy.ma as ma
 from numpy.testing import assert_array_equal
 import unittest
 
-from agg_regrid import agg
+from agg_regrid import agg, DEFAULT_BUFFER_DEPTH
 
 
 class TestDimensionality(unittest.TestCase):
@@ -39,6 +39,7 @@ class TestDimensionality(unittest.TestCase):
         self.sy_dim, self.sx_dim = 1, 2
         self.gx_bounds = np.empty((5, 5))
         self.gy_bounds = np.empty((5, 5))
+        self.depth = DEFAULT_BUFFER_DEPTH
 
     def test_src_x_points(self):
         sx_points = self.sx_points.reshape(1, -1)
@@ -47,7 +48,7 @@ class TestDimensionality(unittest.TestCase):
             agg(self.data, sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_src_y_points(self):
         sy_points = self.sy_points.reshape(1, -1)
@@ -56,7 +57,7 @@ class TestDimensionality(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_src_x_bounds(self):
         sx_bounds = self.sx_bounds.reshape(1, -1)
@@ -65,7 +66,7 @@ class TestDimensionality(unittest.TestCase):
             agg(self.data, self.sx_points, sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_src_y_bounds(self):
         sy_bounds = self.sy_bounds.reshape(1, -1)
@@ -74,7 +75,7 @@ class TestDimensionality(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 self.sy_points, sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_data(self):
         data = self.data.flatten()
@@ -83,7 +84,7 @@ class TestDimensionality(unittest.TestCase):
             agg(data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_src_x_dim(self):
         # Positive index beyond last dimension.
@@ -93,7 +94,7 @@ class TestDimensionality(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_src_y_dim(self):
         # Negative index before first dimension.
@@ -103,7 +104,7 @@ class TestDimensionality(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_grid_x_bounds(self):
         gx_bounds = self.gx_bounds.flatten()
@@ -112,7 +113,7 @@ class TestDimensionality(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                gx_bounds, self.gy_bounds)
+                gx_bounds, self.gy_bounds, self.depth)
 
     def test_grid_y_bounds(self):
         gy_bounds = self.gy_bounds.flatten()
@@ -121,7 +122,7 @@ class TestDimensionality(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, gy_bounds)
+                self.gx_bounds, gy_bounds, self.depth)
 
 
 class TestShape(unittest.TestCase):
@@ -135,6 +136,7 @@ class TestShape(unittest.TestCase):
         self.sy_dim, self.sx_dim = 1, 2
         self.gx_bounds = np.empty((5, 5))
         self.gy_bounds = np.empty((5, 5))
+        self.depth = DEFAULT_BUFFER_DEPTH
 
     def test_src_x_points_and_bounds(self):
         sx_points = np.arange(self.nx - 1)
@@ -143,7 +145,7 @@ class TestShape(unittest.TestCase):
             agg(self.data, sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_src_y_points_and_bounds(self):
         sy_points = np.arange(self.ny - 1)
@@ -152,7 +154,7 @@ class TestShape(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_src_x_points_and_data(self):
         shape = list(self.shape)
@@ -163,7 +165,7 @@ class TestShape(unittest.TestCase):
             agg(data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_src_y_points_and_data(self):
         shape = list(self.shape)
@@ -174,7 +176,7 @@ class TestShape(unittest.TestCase):
             agg(data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_grid_x_bounds_and_y_bounds(self):
         shape = np.array(self.gy_bounds.shape) + 1
@@ -184,7 +186,74 @@ class TestShape(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, gy_bounds)
+                self.gx_bounds, gy_bounds, self.depth)
+
+
+class TestRegridDepth(unittest.TestCase):
+    def setUp(self):
+        # Source has points shape (y:6, x:8)
+        ny, nx = shape = (6, 8)
+        size = np.prod(shape)
+        self.data = np.arange(size).reshape(shape)
+        sx_points = np.arange(1, nx + 1) - 0.5
+        sx_bounds = np.arange(nx + 1)
+        sy_points = np.arange(1, ny + 1) - 0.5
+        sy_bounds = np.arange(ny + 1)
+        sy_dim, sx_dim = 0, 1
+        # Target grid has points shape (y:2, x:2)
+        gx_bounds = np.array([1.5, 4.0, 6.5], dtype=np.float64)
+        gy_bounds = np.array([1.5, 3.0, 4.5], dtype=np.float64)
+        gx_bounds, gy_bounds = np.meshgrid(gx_bounds, gy_bounds)
+        self.args = (self.data, sx_points, sx_bounds,
+                     sy_points, sy_bounds,
+                     sx_dim, sy_dim,
+                     gx_bounds, gy_bounds)
+
+    def _expected(self, depth):
+        data = self.data
+        # Expected raster weights per target grid cell.
+        # This is the (fractional) source cell contribution
+        # to each target cell
+        if depth == 1:
+            weights = np.array([[[63, 127, 127],   # tlhc
+                                 [127, 255, 255]],
+                                [[127, 127, 63],   # trhc)
+                                 [255, 255, 127]],
+                                [[127, 255, 255],  # blhc
+                                 [63, 127, 127]],
+                                [[255, 255, 127],  # brhc
+                                 [127, 127, 63]]], dtype=np.uint8)
+            weights = weights / 255
+        else:
+            weights = np.array([[[0.25, 0.5, 0.5],   # tlhc
+                                 [0.5, 1.0, 1.0]],
+                                [[0.5, 0.5, 0.25],   # trhc
+                                 [1.0, 1.0, 0.5]],
+                                [[0.5, 1.0, 1.0],    # blhc
+                                 [0.25, 0.5, 0.5]],
+                                [[1.0, 1.0, 0.5],    # brhc
+                                 [0.5, 0.5, 0.25]]])
+
+        # Expected source points per target grid cell.
+        tmp = data[1:-1, 1:-1]
+        shape = (-1, 2, 3)
+        cells = [tmp[slice(0, 2), slice(0, 3)].reshape(shape),        # tlhc
+                 tmp[slice(0, 2), slice(3, None)].reshape(shape),     # trhc
+                 tmp[slice(2, None), slice(0, 3)].reshape(shape),     # blhc
+                 tmp[slice(2, None), slice(3, None)].reshape(shape)]  # brhc
+        cells = ma.vstack(cells)
+        # Expected fractional weighted result.
+        num = (cells * weights).sum(axis=(1, 2))
+        dom = weights.sum(axis=(1, 2))
+        expected = num / dom
+        expected = ma.asarray(expected.reshape(2, 2))
+        return expected
+
+    def test(self):
+        for depth in [2**i for i in range(10)]:
+            result = agg(*self.args, depth)
+            expected = self._expected(depth)
+            assert_array_equal(result, self._expected(depth))
 
 
 class TestRegridSingleLevel(unittest.TestCase):
@@ -202,6 +271,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         gx_bounds = np.array([1.5, 4.0, 6.5], dtype=np.float64)
         gy_bounds = np.array([1.5, 3.0, 4.5], dtype=np.float64)
         self.gx_bounds, self.gy_bounds = np.meshgrid(gx_bounds, gy_bounds)
+        self.depth = 1
 
     def _expected(self, transpose=False):
         data = self.data
@@ -210,13 +280,13 @@ class TestRegridSingleLevel(unittest.TestCase):
         # Expected raster weights per target grid cell.
         # This is the (fractional) source cell contribution
         # to each target cell (out of 255)
-        weights = np.array([[[63, 127, 127],   # top left hand cell (tlhc)
+        weights = np.array([[[63, 127, 127],   # tlhc
                              [127, 255, 255]],
-                            [[127, 127, 63],   # top right hand cell (trhc)
+                            [[127, 127, 63],   # trhc
                              [255, 255, 127]],
-                            [[127, 255, 255],  # bottom left hand cell (blhc)
+                            [[127, 255, 255],  # blhc
                              [63, 127, 127]],
-                            [[255, 255, 127],  # bottom right hand cell (brhc)
+                            [[255, 255, 127],  # brhc
                              [127, 127, 63]]], dtype=np.uint8)
         weights = weights / 255
         # Expected source points per target grid cell.
@@ -240,7 +310,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         assert_array_equal(result, self._expected())
 
     def test_regrid_ok_transpose(self):
@@ -249,7 +319,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      sx_dim, sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         expected = self._expected(transpose=True)
         assert_array_equal(result, expected)
 
@@ -268,7 +338,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         assert_array_equal(result, self._expected())
 
     def test_regrid_ok_src_x_points_cast(self):
@@ -276,7 +346,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         assert_array_equal(result, self._expected())
 
     def test_regrid_ok_src_y_points_cast(self):
@@ -284,7 +354,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         assert_array_equal(result, self._expected())
 
     def test_regrid_ok_negative_sx_dim(self):
@@ -292,7 +362,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         assert_array_equal(result, self._expected())
 
     def test_regrid_ok_negative_sy_dim(self):
@@ -300,7 +370,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         assert_array_equal(result, self._expected())
 
     def test_regrid_ok_grid_tlhc_out_of_bounds(self):
@@ -308,7 +378,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         expected = self._expected()
         expected[0, 0] = ma.masked
         assert_array_equal(result, self._expected())
@@ -318,7 +388,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         expected = self._expected()
         expected[0, 1] = ma.masked
         assert_array_equal(result, self._expected())
@@ -328,7 +398,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         expected = self._expected()
         expected[1, 0] = ma.masked
         assert_array_equal(result, self._expected())
@@ -338,7 +408,7 @@ class TestRegridSingleLevel(unittest.TestCase):
         result = agg(self.data, self.sx_points, self.sx_bounds,
                      self.sy_points, self.sy_bounds,
                      self.sx_dim, self.sy_dim,
-                     self.gx_bounds, self.gy_bounds)
+                     self.gx_bounds, self.gy_bounds, self.depth)
         expected = self._expected()
         expected[1, 1] = ma.masked
         assert_array_equal(result, self._expected())
@@ -350,7 +420,7 @@ class TestRegridSingleLevel(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
     def test_regrid_irregular_src_y_points(self):
         self.sy_points[0] = self.sy_points[0] * 1.01
@@ -359,7 +429,7 @@ class TestRegridSingleLevel(unittest.TestCase):
             agg(self.data, self.sx_points, self.sx_bounds,
                 self.sy_points, self.sy_bounds,
                 self.sx_dim, self.sy_dim,
-                self.gx_bounds, self.gy_bounds)
+                self.gx_bounds, self.gy_bounds, self.depth)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR introduces a pixel buffer for each source grid cell during the AGG regrid process.

Although AGG supports sub-pixel accuracy, the limitations of representing a single pixel for each source grid cell covered by a back-projected target cell can yield no result for high resolution target grids.

This is simply because the back-projected target cell is so tiny relative to the source cell, it is simply not possible to render a sub-pixel image of the target cell within the source cell.

The issue is resolved by increasing the number of pixels represented by a source grid cell, which is customisable through the new `buffer_depth` keyword argument to the `AreaWeighted` scheme. The default `buffer_depth` is `8`, giving an `8x8` pixel buffer per source grid cell - which seems a reasonable default, as its a compromise between memory usage, speed of execution and accuracy.